### PR TITLE
1.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to WordPress SVN
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    name: Deploy plugin to WordPress.org
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@v4
+
+      - name: Setup SVN
+        run: sudo apt-get install -y subversion
+
+      - name: Checkout WordPress plugin SVN repository
+        env:
+          SVN_REPO: https://plugins.svn.wordpress.org/email-user-cleaner/
+        run: |
+          svn checkout --username ${{ secrets.SVN_USERNAME }} --password ${{ secrets.SVN_PASSWORD }} $SVN_REPO svn
+
+      - name: Copy files to SVN trunk
+        run: |
+          rsync -av --delete --exclude='.github/' --exclude='.git/' --exclude='.gitignore' --exclude='README.md' ./ svn/trunk/
+
+      - name: SVN Add New Files
+        run: |
+          svn add --force svn/trunk/* --auto-props --parents --depth infinity -q
+
+      - name: SVN Commit trunk changes
+        run: |
+          cd svn
+          svn commit -m "Deploying version $GITHUB_REF_NAME" --username ${{ secrets.SVN_USERNAME }} --password ${{ secrets.SVN_PASSWORD }}
+
+      - name: Create SVN tag
+        run: |
+          cd svn
+          svn copy trunk tags/$GITHUB_REF_NAME
+          svn commit -m "Tagging version $GITHUB_REF_NAME" --username ${{ secrets.SVN_USERNAME }} --password ${{ secrets.SVN_PASSWORD }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,65 @@
+# 🚀 Deployment Instructions for Email User Cleaner
+
+This project uses **GitHub Actions** to automate the deployment of the plugin to the WordPress.org repository.
+
+Follow this guide carefully when releasing a new version.
+
+---
+
+## ✏️ Step 1: Prepare the plugin for release
+
+- Update the **Stable tag** field in `readme.txt` to the new version number (e.g., `Stable tag: 1.7`).
+- Add the new version's **changelog** under the `== Changelog ==` section in `readme.txt`.
+- Update the plugin's **Version** header inside the main PHP file (`email-user-cleaner.php`) if needed.
+- Commit and push your changes to GitHub.
+
+Example:
+
+```bash
+git add .
+git commit -m "Prepare release 1.7"
+git push
+```
+
+---
+
+## 🏷️ Step 2: Create a GitHub Release (Tag)
+
+- Create a new tag that matches the version number (e.g., `1.7`, `1.8.1`, etc.).
+- Push the tag to GitHub.
+
+Example:
+
+```bash
+git tag 1.7
+git push origin 1.7
+```
+
+Alternatively, you can create a **Release** via the GitHub UI, specifying the tag name.
+
+---
+
+## 🤖 Step 3: Automatic Deployment
+
+Once the tag is pushed:
+- The GitHub Action will start automatically.
+- It will:
+  - Sync your plugin files to the **trunk/** directory on WordPress.org SVN.
+  - Create a new SVN **tag** with the version number (e.g., `/tags/1.7`).
+
+You don't need to do anything manually on WordPress.org.
+
+---
+
+## ⚠️ Important notes
+
+- Make sure the tag name **matches exactly** the version number you set in `readme.txt` and the plugin header.
+- Avoid including unnecessary files in the repository (e.g., `.github/`, `.gitignore`, `README.md` are automatically excluded by the workflow).
+
+---
+
+## 💬 Need help?
+
+For any issues with deployment, check the "Actions" tab on GitHub to see the workflow logs.
+
+---

--- a/email-user-cleaner.php
+++ b/email-user-cleaner.php
@@ -3,7 +3,7 @@
 Plugin Name:       E-mail User Cleaner
 Plugin URI:        https://go.gioxx.org/emailusercleaner
 Description:       Delete users corresponding to the specified email addresses, but also search for duplicate users.
-Version:           1.6
+Version:           1.7
 Author:            Gioxx
 Author URI:        https://gioxx.org
 License:           GPL v2 or later
@@ -42,7 +42,7 @@ function euc_enqueue_styles() {
         'euc-styles',
         plugins_url('email-user-cleaner.css', __FILE__),
         array(),
-        '1.6'
+        '1.7'
     );
 }
 add_action('admin_enqueue_scripts', 'euc_enqueue_styles');

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ Install the plugin and activate it. You will find the E-mail User Cleaner entry 
 = 1.7 =
 * Updated compatibility with WordPress 6.8.
 * Added DEPLOY.md to this repository (to make life easier for those who need to release an update on GitHub and then SVN WordPress).
+* Migrate SVN release to GitHub Actions.
 
 = 1.6 =
 * You can now identify duplicated users (based on criteria that checks first name, last name and e-mail address) and decide to select and delete them, also referring to the last login date to the WordPress installation.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://ko-fi.com/gioxx
 Requires at least: 6.0
 Tested up to: 6.7.1
 Requires PHP: 7.4
-Stable tag: 1.6
+Stable tag: 1.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,10 @@ Install the plugin and activate it. You will find the E-mail User Cleaner entry 
 4. The plugin reports that the user corresponding to the administrator's e-mail address has not been deleted for security reasons.
 
 == Changelog ==
+= 1.7 =
+* Updated compatibility with WordPress 6.8.
+* Added DEPLOY.md to this repository (to make life easier for those who need to release an update on GitHub and then SVN WordPress).
+
 = 1.6 =
 * You can now identify duplicated users (based on criteria that checks first name, last name and e-mail address) and decide to select and delete them, also referring to the last login date to the WordPress installation.
 * You can use, for your tests, the Python script generateRandomCSV.py (found in the tools folder of the plugin's GitHub repository) which is able to generate CSVs of fake users complete with first name, last name, email address, which you can import into WordPress (test environment) to play around with this plugin and verify that everything is working properly (you can find two ready-made files already, example_include-names.csv and example_simple.csv).


### PR DESCRIPTION
- Compatibilità con WordPress aggiornata (testato con 6.8).
- Migro il processo di rilascio su SVN WordPress (abbandono SVN in locale e passo a GitHub Action).
- Aggiungo il documento di DEPLOY per chi deve rilasciare GitHub+SVN.